### PR TITLE
处理focus子组件变更后KeyboardInsetsView偏移未正确计算的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ function MyComponent() {
 
 `KeyboardInsetsView` 有两个额外的属性：
 
-- `extraHeight`：自动模式下，键盘总是紧贴着输入框的下边缘，这个属性设置输入框距离键盘的额外高度。
+- `extraHeight`：自动模式下，键盘总是紧贴着输入框的下边缘，这个属性设置输入框距离键盘的额外高度。<u>KeyboardInsetsView 的最大偏移受键盘高度限制，若加入额外高度后，KeyboardInsetsView 偏移距离大于键盘高度，将产生截断，此时 KeyboardInsetsView 偏移距离等于键盘高度，底部将与键盘顶部相贴</u>
 
 - `onKeyboard`：是个回调函数，一旦设置，就进入手动模式，`KeyboardInsetsView` 不会帮你调整输入框的位置。你需要利用这个回调函数实现自己想要的效果。
 

--- a/android/src/main/java/com/reactnative/keyboardinsets/KeyboardInsetsCallback.java
+++ b/android/src/main/java/com/reactnative/keyboardinsets/KeyboardInsetsCallback.java
@@ -104,6 +104,15 @@ public class KeyboardInsetsCallback extends WindowInsetsAnimationCompat.Callback
         if (focusView == null) {
             // Android 10 以下，首次弹出键盘时，不会触发 WindowInsetsAnimationCompat.Callback
             focusView = view.findFocus();
+        } else {
+            View currentFocus = view.findFocus();
+            if ((currentFocus != null && focusView != currentFocus)) {
+                KeyboardInsetsView keyboardInsetsView = findClosestKeyboardInsetsView(focusView);
+                if (keyboardInsetsView != null && keyboardInsetsView.isAutoMode()) {
+                    keyboardInsetsView.setTranslationY(0);
+                }
+                focusView = currentFocus;
+            }
         }
 
         if (shouldHandleKeyboardTransition(focusView)) {

--- a/android/src/main/java/com/reactnative/keyboardinsets/KeyboardInsetsCallback.java
+++ b/android/src/main/java/com/reactnative/keyboardinsets/KeyboardInsetsCallback.java
@@ -144,8 +144,12 @@ public class KeyboardInsetsCallback extends WindowInsetsAnimationCompat.Callback
             EdgeInsets edgeInsets = SystemUI.getEdgeInsetsForView(focusView);
             float extraHeight = PixelUtil.toPixelFromDIP(view.getExtraHeight());
             Log.d("KeyboardInsets", "edgeInsets.bottom:" + edgeInsets.bottom + " imeInsets.bottom:" + imeInsets.bottom);
-            view.setTranslationY(-Math.max(imeInsets.bottom - edgeInsets.bottom + extraHeight, 0));
-
+            float translationY = 0;
+            if (imeInsets.bottom > 0) {
+                float actualBottomInset = Math.max(edgeInsets.bottom - extraHeight, 0);
+                translationY = -Math.max(imeInsets.bottom - actualBottomInset, 0);
+            }
+            view.setTranslationY(translationY);
         } else {
             Log.d("KeyboardInsets", "imeInsets.bottom:" + imeInsets.bottom);
             sendEvent(new KeyboardPositionChangedEvent(view.getId(), imeInsets.bottom));

--- a/android/src/main/java/com/reactnative/keyboardinsets/KeyboardInsetsView.java
+++ b/android/src/main/java/com/reactnative/keyboardinsets/KeyboardInsetsView.java
@@ -1,6 +1,7 @@
 package com.reactnative.keyboardinsets;
 
 import android.content.Context;
+import android.view.View;
 
 import com.facebook.react.views.view.ReactViewGroup;
 
@@ -29,5 +30,11 @@ public class KeyboardInsetsView extends ReactViewGroup {
     public float getExtraHeight() {
         return this.extraHeight;
     }
-    
+
+
+    @Override
+    public void requestChildFocus(View child, View focused) {
+        super.requestChildFocus(child, focused);
+        requestApplyInsets();
+    }
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -22,7 +22,7 @@ function App() {
             />
           ))}
         </ScrollView>
-        <KeyboardInsetsView extraHeight={16} style={[styles.keyboard, styles.backgroundLime]}>
+        <KeyboardInsetsView extraHeight={40} style={[styles.keyboard, styles.backgroundLime]}>
           <TextInput style={styles.input} placeholder={'test keyboard instes'} textAlignVertical="center" />
           <SafeAreaView edges={['bottom']} />
         </KeyboardInsetsView>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment, useRef } from 'react'
 import { withNavigationItem } from 'hybrid-navigation'
 import { StyleSheet, TextInput, ScrollView } from 'react-native'
 import { KeyboardInsetsView } from 'react-native-keyboard-insets'
@@ -7,16 +7,9 @@ import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 function App() {
   return (
     <SafeAreaProvider>
-      <KeyboardInsetsView extraHeight={16} style={{ flex: 1 }}>
+      <KeyboardInsetsView extraHeight={16} style={styles.flex1}>
         <ScrollView contentContainerStyle={styles.container}>
-          {Array.from({ length: 9 }).map((item, index) => (
-            <TextInput
-              key={index}
-              style={styles.input}
-              placeholder={`test keyboard instes ${index}`}
-              textAlignVertical="center"
-            />
-          ))}
+          <SubmitToNextInputFragment />
           <KeyboardInsetsView extraHeight={16} style={styles.keyboard}>
             <TextInput style={styles.input} placeholder={'test keyboard instes'} textAlignVertical="center" />
           </KeyboardInsetsView>
@@ -29,12 +22,39 @@ function App() {
             />
           ))}
         </ScrollView>
-        <KeyboardInsetsView extraHeight={16} style={[styles.keyboard, { backgroundColor: 'lime' }]}>
+        <KeyboardInsetsView extraHeight={16} style={[styles.keyboard, styles.backgroundLime]}>
           <TextInput style={styles.input} placeholder={'test keyboard instes'} textAlignVertical="center" />
           <SafeAreaView edges={['bottom']} />
         </KeyboardInsetsView>
       </KeyboardInsetsView>
     </SafeAreaProvider>
+  )
+}
+
+const inputLength = 9
+function SubmitToNextInputFragment() {
+  const inputRef = useRef<(TextInput | null)[]>([...Array(inputLength)])
+  const goNextInput = (index: number) => {
+    if (index !== inputLength - 1) {
+      inputRef.current[index + 1]?.focus()
+    }
+  }
+  return (
+    <Fragment>
+      {Array.from({ length: inputLength }).map((_, index) => (
+        <TextInput
+          ref={ref => (inputRef.current[index] = ref)}
+          key={index}
+          style={styles.input}
+          placeholder={index === inputLength - 1 ? 'submit' : `current:${index} => submit and next`}
+          textAlignVertical="center"
+          blurOnSubmit={index === inputLength - 1}
+          autoCorrect={false}
+          returnKeyType={index === inputLength - 1 ? 'done' : 'next'}
+          onSubmitEditing={() => goNextInput(index)}
+        />
+      ))}
+    </Fragment>
   )
 }
 
@@ -51,6 +71,12 @@ export default withNavigationItem({
 })(App)
 
 const styles = StyleSheet.create({
+  flex1: {
+    flex: 1,
+  },
+  backgroundLime: {
+    backgroundColor: 'lime',
+  },
   container: {
     justifyContent: 'flex-start',
     alignItems: 'stretch',
@@ -58,7 +84,7 @@ const styles = StyleSheet.create({
   },
 
   input: {
-    height: 40,
+    height: 80,
     marginHorizontal: 48,
     marginTop: 16,
     marginBottom: 0,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -282,7 +282,7 @@ PODS:
     - React-jsi (= 0.67.4)
     - React-logger (= 0.67.4)
     - React-perflogger (= 0.67.4)
-  - RNKeyboardInsets (1.0.1):
+  - RNKeyboardInsets (1.1.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -428,9 +428,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 3b52a7dced19cdb025b4f88ab26ceb2d85f30ba2
   React-runtimeexecutor: a9d3c82ddf7ffdad9fbe6a81c6d6f8c06385464d
   ReactCommon: 07d0c460b9ba9af3eaf1b8f5abe7daaad28c9c4e
-  RNKeyboardInsets: 6abccdbd2020721417a50b634169496a08df9dd0
+  RNKeyboardInsets: 885efbfa90f79a532c23251937afde83240142fd
   Yoga: d6b6a80659aa3e91aaba01d0012e7edcbedcbecd
 
-PODFILE CHECKSUM: 5f8e27516be9e29e667680d1a90470ffeb5a4037
+PODFILE CHECKSUM: a528f2e9b1fc1781e92492211061ea07bb9b767a
 
 COCOAPODS: 1.11.3

--- a/ios/KeyboardInsets/HBDKeyboardInsetsView.m
+++ b/ios/KeyboardInsets/HBDKeyboardInsetsView.m
@@ -195,7 +195,11 @@
 - (void)handleKeyboardTransition:(CGFloat)position {
     if ([self isAutoMode]) {
         if (_focusView) {
-            CGFloat translationY = -MAX(position - _edgeBottom + self.extraHeight, 0);
+            CGFloat translationY = 0;
+            if (position > 0) {
+                CGFloat actualEdgeBottom = MAX(_edgeBottom - _extraHeight, 0);
+                translationY = -MAX(position - actualEdgeBottom, 0);
+            }
             self.transform = CGAffineTransformMakeTranslation(0, translationY);
         }
     } else {

--- a/ios/KeyboardInsets/HBDKeyboardInsetsView.m
+++ b/ios/KeyboardInsets/HBDKeyboardInsetsView.m
@@ -72,19 +72,42 @@
             @"transitioning": @(YES),
         });
     }
-    
-    if ([self isAutoMode] && CGAffineTransformEqualToTransform(self.transform, CGAffineTransformIdentity)) {
-        CGRect windowFrame = [self.window convertRect:focusView.frame fromView:focusView.superview];
-        _edgeBottom = MAX(CGRectGetMaxY(self.window.bounds) - CGRectGetMaxY(windowFrame), 0);
-    }
+
+    [self refreshEdgeBottom];
     
     RCTLogInfo(@"[KeyboardInsetsView] keyboardWillShow startWatchKeyboardTransition");
     [self startWatchKeyboardTransition];
 }
 
+- (void)refreshEdgeBottom {
+    if ([self isAutoMode]) {
+        CGFloat translateY = self.transform.ty;
+        CGRect windowFrame = [self.window convertRect:_focusView.frame fromView:_focusView.superview];
+        CGFloat newEdgeBottom = MAX(CGRectGetMaxY(self.window.bounds) - CGRectGetMaxY(windowFrame) + translateY, 0);
+        if (_edgeBottom == 0 || _edgeBottom != newEdgeBottom){
+            _edgeBottom = newEdgeBottom;
+        }
+    }
+}
+
 - (void)keyboardDidShow:(NSNotification *)notification {
     if ([self shouldHandleKeyboardTransition:_focusView]) {
+        UIView *focusView = [HBDKeyboardInsetsView findFocusView:self];
         [self stopWatchKeyboardTransition];
+        if (!focusView) {
+            [self handleKeyboardTransition:0];
+            _focusView = nil;
+            return;
+        }else if (_focusView != focusView) {
+            HBDKeyboardInsetsView *keyboardInsetsView = [HBDKeyboardInsetsView findClosetKeyboardInsetsView:focusView];
+            if (self != keyboardInsetsView) {
+                [self handleKeyboardTransition:0];
+                [keyboardInsetsView refreshEdgeBottom];
+                [keyboardInsetsView handleKeyboardTransition:_keyboardHeight];
+            }
+            _focusView = focusView;
+            return;
+        }
         [self handleKeyboardTransition:_keyboardHeight];
         
         if (![self isAutoMode]) {
@@ -117,9 +140,8 @@
 
 
 - (void)keyboardDidHide:(NSNotification *)notification {
+    [self stopWatchKeyboardTransition];
     if ([self shouldHandleKeyboardTransition:_focusView]) {
-        
-        [self stopWatchKeyboardTransition];
         [self handleKeyboardTransition:0];
         
         if (![self isAutoMode]) {
@@ -154,8 +176,10 @@
 }
 
 - (void)stopWatchKeyboardTransition {
-    [_displayLink invalidate];
-    _displayLink = nil;
+    if(_displayLink){
+        [_displayLink invalidate];
+        _displayLink = nil;
+    }
 }
 
 - (void)watchKeyboardTransition {


### PR DESCRIPTION
当前的设计流程是：blur => focus 也就是一个组件在focus之前，KeyboardInsetsView必定是blur状态；
但实际可以是：blur => child a focus => child b focus 也就是一个组件在focus之前，KeyboardInsetsView可以处于focus状态。
而KeyboardInsetsView偏移的计算根据的是focus组件的位置，在focus状态子组件发生变化后，KeyboardInsetsView偏移的计算仍然依赖于原先的focus组件，因而将导致错误。